### PR TITLE
Make copier template work on windows

### DIFF
--- a/.changeset/eleven-gorillas-cross.md
+++ b/.changeset/eleven-gorillas-cross.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/creta-project-template": patch
+---
+
+Template would fail on Windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+venv/

--- a/copier.yaml
+++ b/copier.yaml
@@ -70,9 +70,9 @@ vocabs:
   help: >-
     Additional vocabularies to insert to the store from vocabulary packages.
     
-    ⚠️ This must be an array and every entry should be formatted as described on https://creta.hypermedia.app/#/talos?id=additional-vocabularies
+    NOTE: This must be an array and every entry should be formatted as described on https://creta.hypermedia.app/#/talos?id=additional-vocabularies
 
-    💡 For example:
+    For example:
       - "@zazuko/rdf-vocabularies,dash,geo"
       - "@org/vocabularies"
 


### PR DESCRIPTION
As per description. 

Lesson learned (the hard way..): Copier only recognises code changes via the tags - i.e. it doesn't use the latest code in master branch but the latest state as of the most-recent repo tag. 
So for now it will still use the old, windows-breaking yaml file version until we don't make a new tag on this repo that includes this change (even if this PR gets merged and is in the codebase, to my understanding of things).