### PR TITLE
Wrong arguments generated in copier command

### DIFF
--- a/.changeset/chilled-doors-arrive.md
+++ b/.changeset/chilled-doors-arrive.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/creta-project-template": patch
+---
+
+Wrong arguments generated in copier update

--- a/copier.yaml
+++ b/copier.yaml
@@ -17,7 +17,7 @@ _tasks:
   - '{% for api in apis %}npx npm-add-script -f -k copier:{{api}} -v "copier -a .copier-{{api}}.yaml update"; {% endfor %}'
   - 'npx npm-add-script -f -k "bootstrap:vocabs" -v "talos put-vocabs --endpoint \$SPARQL_ENDPOINT --user \$SPARQL_USER --password \$SPARQL_PASSWORD{% for vocab_spec in vocabs %} --extraVocabs {{vocab_spec}}{% endfor %}"'
   - 'npx npm-add-script -f -k start -v "knossos-ts serve \$SPARQL_ENDPOINT --name \$APP_NAME --user \$SPARQL_USER --password \$SPARQL_PASSWORD{% if apis|length > 1 %} --routePath "\$API_ROOTS"{% endif %}"'
-  - 'npx npm-add-script -f -k "copier:root" -v "copier -a{% for api in apis %} -s apps/{{api}}{% endfor %} {{_copier_conf.answers_file}} update"'
+  - 'npx npm-add-script -f -k "copier:root" -v "copier -a {{_copier_conf.answers_file}}{% for api in apis %} -s apps/{{api}}{% endfor %} update"'
   - "npx json -If package.json 
       -e 'this.name=\"{{app_name}}\"'
       -e 'this.author=\"{{author}} <{{email}}>\"'


### PR DESCRIPTION
```diff
-  "copier:root": "copier -a -s apps/todos -s apps/users .copier-creta.yaml update",
+  "copier:root": "copier -a .copier-creta.yaml -s apps/todos -s apps/users update",
```